### PR TITLE
fix sync/status api at startups

### DIFF
--- a/sync/api.go
+++ b/sync/api.go
@@ -22,11 +22,19 @@ func HandleStatus(w http.ResponseWriter, _ *http.Request) {
 		log.Error("/sync/status GetBlockCount failed", logger.Attrs{"err": err})
 	}
 
+	height := int64(0)
+	time := int64(0)
+
+	if lb != nil && lb.Block != nil {
+		height = lb.Block.Height
+		time = lb.Block.Time
+	}
+
 	httpapi.RespondJSON(w, http.StatusOK, map[string]interface{}{
 		"IsInitialSync": IsInitialSync,
-		"Height":        lb.Block.Height,
-		"Timestamp":     lb.Block.Time,
+		"Height":        height,
+		"Timestamp":     time,
 		"LatestHeight":  count,
-		"Progress":      float64(lb.Block.Height) / float64(count),
+		"Progress":      float64(height) / float64(count),
 	})
 }


### PR DESCRIPTION
```
2019/03/26 00:38:45 http: panic serving 130.211.0.157:36432: runtime error: invalid memory address or nil pointer dereference
goroutine 14 [running]:
net/http.(*conn).serve.func1(0xc0001068c0)
	/usr/local/go/src/net/http/server.go:1769 +0xc9
panic(0xcac820, 0x170dd80)
	/usr/local/go/src/runtime/panic.go:522 +0x1b5
github.com/bitspill/oip/sync.HandleStatus(0x1013160, 0xc00011a0e0, 0xc00017ae00)
	/go/src/github.com/bitspill/oip/sync/api.go:27 +0xe7
net/http.HandlerFunc.ServeHTTP(0xf1c1a8, 0x1013160, 0xc00011a0e0, 0xc00017ae00)
	/usr/local/go/src/net/http/server.go:1995 +0x44
github.com/bitspill/oip/httpapi.commonParameterParser.func1(0x1013160, 0xc00011a0e0, 0xc00017ad00)
	/go/src/github.com/bitspill/oip/httpapi/commonParams.go:88 +0x3f6
net/http.HandlerFunc.ServeHTTP(0xc0001365c0, 0x1013160, 0xc00011a0e0, 0xc00017ad00)
	/usr/local/go/src/net/http/server.go:1995 +0x44
github.com/bitspill/oip/httpapi.logRequests.func1(0x1013160, 0xc00011a0e0, 0xc00017ad00)
	/go/src/github.com/bitspill/oip/httpapi/log.go:14 +0xfa
net/http.HandlerFunc.ServeHTTP(0xc0001365e0, 0x1013160, 0xc00011a0e0, 0xc00017ad00)
	/usr/local/go/src/net/http/server.go:1995 +0x44
github.com/bitspill/oip/vendor/github.com/gorilla/mux.(*Router).ServeHTTP(0xc000124300, 0x1013160, 0xc00011a0e0, 0xc00017aa00)
	/go/src/github.com/bitspill/oip/vendor/github.com/gorilla/mux/mux.go:212 +0xce
github.com/bitspill/oip/vendor/github.com/rs/cors.(*Cors).Handler.func1(0x1013160, 0xc00011a0e0, 0xc00017aa00)
	/go/src/github.com/bitspill/oip/vendor/github.com/rs/cors/cors.go:207 +0xc2
net/http.HandlerFunc.ServeHTTP(0xc00054e120, 0x1013160, 0xc00011a0e0, 0xc00017aa00)
	/usr/local/go/src/net/http/server.go:1995 +0x44
github.com/bitspill/oip/vendor/github.com/gorilla/handlers.CompressHandlerLevel.func1(0x1013160, 0xc00011a0e0, 0xc00017aa00)
	/go/src/github.com/bitspill/oip/vendor/github.com/gorilla/handlers/compress.go:146 +0x1aa
net/http.HandlerFunc.ServeHTTP(0xc00054e140, 0x1013160, 0xc00011a0e0, 0xc00017aa00)
	/usr/local/go/src/net/http/server.go:1995 +0x44
net/http.serverHandler.ServeHTTP(0xc000096340, 0x1013160, 0xc00011a0e0, 0xc00017aa00)
	/usr/local/go/src/net/http/server.go:2774 +0xab
net/http.(*conn).serve(0xc0001068c0, 0x1016460, 0xc0001e0200)
	/usr/local/go/src/net/http/server.go:1878 +0x84c
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:2884 +0x2f4
```