### PR TITLE
add `pretty` option to all JSON api routes

### DIFF
--- a/httpapi/artifacts.go
+++ b/httpapi/artifacts.go
@@ -31,7 +31,7 @@ func handleArtifactSearch(w http.ResponseWriter, r *http.Request) {
 
 	searchQuery, err := url.PathUnescape(opts["query"])
 	if err != nil {
-		RespondJSON(w, 400, map[string]interface{}{
+		RespondJSON(r.Context(), w, 400, map[string]interface{}{
 			"error": "unable to decode query",
 		})
 		return
@@ -56,7 +56,7 @@ func handleArtifactSearch(w http.ResponseWriter, r *http.Request) {
 		artifactFsc,
 	)
 
-	RespondSearch(w, searchService)
+	RespondSearch(r.Context(), w, searchService)
 }
 
 func handleLatest(w http.ResponseWriter, r *http.Request) {
@@ -82,7 +82,7 @@ func handleLatest(w http.ResponseWriter, r *http.Request) {
 		artifactFsc,
 	)
 
-	RespondSearch(w, searchService)
+	RespondSearch(r.Context(), w, searchService)
 }
 
 func handleGet(w http.ResponseWriter, r *http.Request) {
@@ -105,7 +105,7 @@ func handleGet(w http.ResponseWriter, r *http.Request) {
 		artifactFsc,
 	)
 
-	RespondSearch(w, searchService)
+	RespondSearch(r.Context(), w, searchService)
 }
 
 func handleCardinality(w http.ResponseWriter, r *http.Request) {
@@ -127,17 +127,17 @@ func handleCardinality(w http.ResponseWriter, r *http.Request) {
 		Do(context.TODO())
 
 	if err != nil {
-		RespondESError(w, err)
+		RespondESError(r.Context(), w, err)
 		return
 	}
 
 	agg, ok := s.Aggregations.Cardinality("cardinality")
 	if !ok {
-		RespondESError(w, errors.New("cardinality not found"))
+		RespondESError(r.Context(), w, errors.New("cardinality not found"))
 		return
 	}
 
-	RespondJSON(w, http.StatusOK, map[string]interface{}{
+	RespondJSON(r.Context(), w, http.StatusOK, map[string]interface{}{
 		"c": agg.Value,
 		"f": opts["field"],
 	})

--- a/httpapi/flo.go
+++ b/httpapi/flo.go
@@ -40,7 +40,7 @@ func handleGetFloData(w http.ResponseWriter, r *http.Request) {
 		[]elastic.SortInfo{{Field: "tx.txid", Ascending: false}},
 		floDataFsc,
 	)
-	RespondSearch(w, searchService)
+	RespondSearch(r.Context(), w, searchService)
 }
 
 func handleFloDataSearch(w http.ResponseWriter, r *http.Request) {
@@ -48,7 +48,7 @@ func handleFloDataSearch(w http.ResponseWriter, r *http.Request) {
 
 	searchQuery, err := url.PathUnescape(opts["query"])
 	if err != nil {
-		RespondJSON(w, 400, map[string]interface{}{
+		RespondJSON(r.Context(), w, 400, map[string]interface{}{
 			"error": "unable to decode query",
 		})
 		return
@@ -71,7 +71,7 @@ func handleFloDataSearch(w http.ResponseWriter, r *http.Request) {
 		floDataFsc,
 	)
 
-	RespondSearch(w, searchService)
+	RespondSearch(r.Context(), w, searchService)
 }
 
 func handleFloDataLatest(w http.ResponseWriter, r *http.Request) {
@@ -93,7 +93,7 @@ func handleFloDataLatest(w http.ResponseWriter, r *http.Request) {
 		floDataFsc,
 	)
 
-	RespondSearch(w, searchService)
+	RespondSearch(r.Context(), w, searchService)
 }
 
 func handleFloTxLatest(w http.ResponseWriter, r *http.Request) {
@@ -117,7 +117,7 @@ func handleFloTxLatest(w http.ResponseWriter, r *http.Request) {
 		nil,
 	)
 
-	RespondSearch(w, searchService)
+	RespondSearch(r.Context(), w, searchService)
 }
 
 func handleGetFloTx(w http.ResponseWriter, r *http.Request) {
@@ -135,7 +135,7 @@ func handleGetFloTx(w http.ResponseWriter, r *http.Request) {
 		[]elastic.SortInfo{{Field: "tx.txid", Ascending: false}},
 		nil,
 	)
-	RespondSearch(w, searchService)
+	RespondSearch(r.Context(), w, searchService)
 }
 
 func handleFloTxSearch(w http.ResponseWriter, r *http.Request) {
@@ -143,7 +143,7 @@ func handleFloTxSearch(w http.ResponseWriter, r *http.Request) {
 
 	searchQuery, err := url.PathUnescape(opts["query"])
 	if err != nil {
-		RespondJSON(w, 400, map[string]interface{}{
+		RespondJSON(r.Context(), w, 400, map[string]interface{}{
 			"error": "unable to decode query",
 		})
 		return
@@ -171,5 +171,5 @@ func handleFloTxSearch(w http.ResponseWriter, r *http.Request) {
 		nil,
 	)
 
-	RespondSearch(w, searchService)
+	RespondSearch(r.Context(), w, searchService)
 }

--- a/httpapi/handlers.go
+++ b/httpapi/handlers.go
@@ -9,8 +9,8 @@ import (
 	"github.com/oipwg/oip/version"
 )
 
-func handleVersion(w http.ResponseWriter, _ *http.Request) {
-	RespondJSON(w, http.StatusOK, map[string]string{
+func handleVersion(w http.ResponseWriter, r *http.Request) {
+	RespondJSON(r.Context(), w, http.StatusOK, map[string]string{
 		"BuiltBy":       version.BuiltBy,
 		"BuildDate":     version.BuildDate,
 		"GoVersion":     version.GoVersion,

--- a/httpapi/httpapi.go
+++ b/httpapi/httpapi.go
@@ -43,8 +43,15 @@ func NewSubRoute(prefix string) *mux.Router {
 	return rootRouter.PathPrefix(prefix).Subrouter()
 }
 
-func RespondJSON(w http.ResponseWriter, code int, payload interface{}) {
-	b, err := json.Marshal(payload)
+func RespondJSON(ctx context.Context, w http.ResponseWriter, code int, payload interface{}) {
+	pretty := GetPrettyJsonFromContext(ctx)
+	var b []byte
+	var err error
+	if pretty {
+		b, err = json.MarshalIndent(payload, "", " ")
+	} else {
+		b, err = json.Marshal(payload)
+	}
 	if err != nil {
 		log.Error("Unable to marshal response payload", logger.Attrs{"err": err, "payload": spew.Sdump(payload)})
 		w.Header().Set("Content-Type", "text/plain")
@@ -64,29 +71,29 @@ func RespondJSON(w http.ResponseWriter, code int, payload interface{}) {
 	}
 }
 
-func RespondESError(w http.ResponseWriter, err error) {
+func RespondESError(ctx context.Context, w http.ResponseWriter, err error) {
 	if elasticErr, ok := err.(*elastic.Error); ok {
 		if elasticErr.Status == 400 {
-			RespondJSON(w, 400, map[string]interface{}{
+			RespondJSON(ctx, w, 400, map[string]interface{}{
 				"error": "invalid search request",
 			})
 			return
 		}
 	}
-	RespondJSON(w, 500, map[string]interface{}{
+	RespondJSON(ctx, w, 500, map[string]interface{}{
 		"error": "unable to execute search",
 	})
 }
 
-func RespondSearch(w http.ResponseWriter, searchService *elastic.SearchService) {
+func RespondSearch(ctx context.Context, w http.ResponseWriter, searchService *elastic.SearchService) {
 	results, err := searchService.Do(context.TODO())
 	if err != nil {
 		log.Error("elastic search failed", logger.Attrs{"err": err, "results": results})
-		RespondESError(w, err)
+		RespondESError(ctx, w, err)
 		return
 	}
-	sources, nextAfter := ExtractSources(results)
-	RespondJSON(w, http.StatusOK, map[string]interface{}{
+	sources, nextAfter := ExtractSources(results, GetPrettyJsonFromContext(ctx))
+	RespondJSON(ctx, w, http.StatusOK, map[string]interface{}{
 		"count":   len(results.Hits.Hits),
 		"total":   results.Hits.TotalHits,
 		"results": sources,

--- a/modules/alexandriaMedia/alexandria-media.go
+++ b/modules/alexandriaMedia/alexandria-media.go
@@ -38,7 +38,7 @@ func handleLatest(w http.ResponseWriter, r *http.Request) {
 		elastic.NewTermQuery("meta.deactivated", false),
 	)
 	searchService := httpapi.BuildCommonSearchService(r.Context(), amIndices, q, []elastic.SortInfo{{Field: "meta.time", Ascending: false}}, amFsc)
-	httpapi.RespondSearch(w, searchService)
+	httpapi.RespondSearch(r.Context(), w, searchService)
 }
 
 func handleGet(w http.ResponseWriter, r *http.Request) {
@@ -49,7 +49,7 @@ func handleGet(w http.ResponseWriter, r *http.Request) {
 		elastic.NewPrefixQuery("meta.txid", opts["id"]),
 	)
 	searchService := httpapi.BuildCommonSearchService(r.Context(), amIndices, q, []elastic.SortInfo{{Field: "meta.time", Ascending: false}}, amFsc)
-	httpapi.RespondSearch(w, searchService)
+	httpapi.RespondSearch(r.Context(), w, searchService)
 }
 
 func onAlexandriaMedia(floData string, tx *datastore.TransactionData) {

--- a/modules/alexandriaMedia/alexandria-publisher.go
+++ b/modules/alexandriaMedia/alexandria-publisher.go
@@ -43,7 +43,7 @@ func handleLatestPublishers(w http.ResponseWriter, r *http.Request) {
 		[]elastic.SortInfo{{Field: "timestamp", Ascending: false}},
 		apFsc,
 	)
-	httpapi.RespondSearch(w, searchService)
+	httpapi.RespondSearch(r.Context(), w, searchService)
 }
 
 func handleGetPublisher(w http.ResponseWriter, r *http.Request) {
@@ -60,7 +60,7 @@ func handleGetPublisher(w http.ResponseWriter, r *http.Request) {
 		[]elastic.SortInfo{{Field: "timestamp", Ascending: false}},
 		apFsc,
 	)
-	httpapi.RespondSearch(w, searchService)
+	httpapi.RespondSearch(r.Context(), w, searchService)
 }
 
 func onAlexandriaPublisher(floData string, tx *datastore.TransactionData) {

--- a/modules/historian/historian.go
+++ b/modules/historian/historian.go
@@ -57,7 +57,7 @@ func handleLatest(w http.ResponseWriter, r *http.Request) {
 		},
 		hdpFsc,
 	)
-	httpapi.RespondSearch(w, searchService)
+	httpapi.RespondSearch(r.Context(), w, searchService)
 }
 
 func handleGet(w http.ResponseWriter, r *http.Request) {
@@ -77,12 +77,12 @@ func handleGet(w http.ResponseWriter, r *http.Request) {
 		},
 		hdpFsc,
 	)
-	httpapi.RespondSearch(w, searchService)
+	httpapi.RespondSearch(r.Context(), w, searchService)
 }
 
 func handle24hr(w http.ResponseWriter, r *http.Request) {
 	// ToDo
-	httpapi.RespondJSON(w, http.StatusBadRequest, map[string]interface{}{
+	httpapi.RespondJSON(r.Context(), w, http.StatusBadRequest, map[string]interface{}{
 		"err": "not implemented",
 	})
 }

--- a/modules/oip/multipart.go
+++ b/modules/oip/multipart.go
@@ -54,7 +54,7 @@ func handleGetId(w http.ResponseWriter, r *http.Request) {
 	)
 
 	searchService := httpapi.BuildCommonSearchService(r.Context(), mpIndices, q, []elastic.SortInfo{{Field: "meta.time", Ascending: false}}, mpFsc)
-	httpapi.RespondSearch(w, searchService)
+	httpapi.RespondSearch(r.Context(), w, searchService)
 }
 
 func handleGetRef(w http.ResponseWriter, r *http.Request) {
@@ -65,7 +65,7 @@ func handleGetRef(w http.ResponseWriter, r *http.Request) {
 	)
 
 	searchService := httpapi.BuildCommonSearchService(r.Context(), mpIndices, q, []elastic.SortInfo{{Field: "meta.time", Ascending: false}}, mpFsc)
-	httpapi.RespondSearch(w, searchService)
+	httpapi.RespondSearch(r.Context(), w, searchService)
 }
 
 func onDatastoreCommit() {
@@ -116,7 +116,7 @@ moreMultiparts:
 
 	// If we are not still syncing for the first time, and the remaining count is exactly the same as last time we checked,
 	// then it is a good indicator that these Multiparts are stale
-	if (!wasInitialSync && previousMultipartCount == len(multiparts) && previousMultipartCount < 10000) {
+	if !wasInitialSync && previousMultipartCount == len(multiparts) && previousMultipartCount < 10000 {
 		// ToDo: Consider re-enabling after further tests under high volume
 		markStale()
 	}

--- a/modules/oip041/oip041.go
+++ b/modules/oip041/oip041.go
@@ -54,7 +54,7 @@ func handleLatest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	searchService := httpapi.BuildCommonSearchService(r.Context(), o41Indices, q, []elastic.SortInfo{{Field: "meta.time", Ascending: false}}, o41Fsc)
-	httpapi.RespondSearch(w, searchService)
+	httpapi.RespondSearch(r.Context(), w, searchService)
 }
 
 func handleGet(w http.ResponseWriter, r *http.Request) {
@@ -67,7 +67,7 @@ func handleGet(w http.ResponseWriter, r *http.Request) {
 	)
 
 	searchService := httpapi.BuildCommonSearchService(r.Context(), o41Indices, q, []elastic.SortInfo{{Field: "meta.time", Ascending: false}}, o41Fsc)
-	httpapi.RespondSearch(w, searchService)
+	httpapi.RespondSearch(r.Context(), w, searchService)
 }
 
 func on41(floData string, tx *datastore.TransactionData) {

--- a/modules/oip042/api.go
+++ b/modules/oip042/api.go
@@ -56,7 +56,7 @@ func handleLatest(w http.ResponseWriter, r *http.Request) {
 		},
 		o42ArtifactFsc,
 	)
-	httpapi.RespondSearch(w, searchService)
+	httpapi.RespondSearch(r.Context(), w, searchService)
 }
 
 /**
@@ -92,7 +92,7 @@ func handleGetLatestEdit(response http.ResponseWriter, request *http.Request) {
 		},
 		o42ArtifactFsc,
 	)
-	httpapi.RespondSearch(response, searchService)
+	httpapi.RespondSearch(request.Context(), response, searchService)
 }
 
 /**
@@ -129,7 +129,7 @@ func handleGetForVersion(response http.ResponseWriter, request *http.Request) {
 		},
 		o42ArtifactFsc,
 	)
-	httpapi.RespondSearch(response, searchService)
+	httpapi.RespondSearch(request.Context(), response, searchService)
 }
 
 /**
@@ -150,7 +150,7 @@ func handleGetEditRecord(response http.ResponseWriter, request *http.Request) {
 		[]elastic.SortInfo{},
 		o42EditFsc,
 	)
-	httpapi.RespondSearch(response, searchService)
+	httpapi.RespondSearch(request.Context(), response, searchService)
 }
 
 func handleEditSearch(w http.ResponseWriter, r *http.Request) {
@@ -158,7 +158,7 @@ func handleEditSearch(w http.ResponseWriter, r *http.Request) {
 
 	searchQuery, err := url.PathUnescape(opts["query"])
 	if err != nil {
-		httpapi.RespondJSON(w, 400, map[string]interface{}{
+		httpapi.RespondJSON(r.Context(), w, 400, map[string]interface{}{
 			"error": "unable to decode query",
 		})
 		return
@@ -178,5 +178,5 @@ func handleEditSearch(w http.ResponseWriter, r *http.Request) {
 		o42EditFsc,
 	)
 
-	httpapi.RespondSearch(w, searchService)
+	httpapi.RespondSearch(r.Context(), w, searchService)
 }

--- a/modules/oip5/api.go
+++ b/modules/oip5/api.go
@@ -39,7 +39,7 @@ func handleRecordSearch(w http.ResponseWriter, r *http.Request) {
 	// log.Info("handleSearchRecord", logger.Attrs{"opts": opts})
 	searchQuery, err := url.PathUnescape(opts["query"])
 	if err != nil {
-		httpapi.RespondJSON(w, 400, map[string]interface{}{
+		httpapi.RespondJSON(r.Context(), w, 400, map[string]interface{}{
 			"error": "unable to decode query",
 		})
 		return
@@ -63,7 +63,7 @@ func handleRecordSearch(w http.ResponseWriter, r *http.Request) {
 		o5Fsc,
 	)
 
-	httpapi.RespondSearch(w, searchService)
+	httpapi.RespondSearch(r.Context(), w, searchService)
 }
 
 func handleTemplateSearch(w http.ResponseWriter, r *http.Request) {
@@ -71,7 +71,7 @@ func handleTemplateSearch(w http.ResponseWriter, r *http.Request) {
 
 	searchQuery, err := url.PathUnescape(opts["query"])
 	if err != nil {
-		httpapi.RespondJSON(w, 400, map[string]interface{}{
+		httpapi.RespondJSON(r.Context(), w, 400, map[string]interface{}{
 			"error": "unable to decode query",
 		})
 		return
@@ -93,7 +93,7 @@ func handleTemplateSearch(w http.ResponseWriter, r *http.Request) {
 		o5Fsc,
 	)
 
-	httpapi.RespondSearch(w, searchService)
+	httpapi.RespondSearch(r.Context(), w, searchService)
 }
 
 func handleLatestRecord(w http.ResponseWriter, r *http.Request) {
@@ -111,7 +111,7 @@ func handleLatestRecord(w http.ResponseWriter, r *http.Request) {
 		o5Fsc,
 	)
 
-	httpapi.RespondSearch(w, searchService)
+	httpapi.RespondSearch(r.Context(), w, searchService)
 }
 
 func handleGetRecord(w http.ResponseWriter, r *http.Request) {
@@ -130,7 +130,7 @@ func handleGetRecord(w http.ResponseWriter, r *http.Request) {
 		o5Fsc,
 	)
 
-	httpapi.RespondSearch(w, searchService)
+	httpapi.RespondSearch(r.Context(), w, searchService)
 }
 
 func handleGetMapping(w http.ResponseWriter, r *http.Request) {
@@ -151,7 +151,7 @@ func handleGetMapping(w http.ResponseWriter, r *http.Request) {
 		Do(r.Context())
 
 	if err != nil {
-		httpapi.RespondESError(w, err)
+		httpapi.RespondESError(r.Context(), w, err)
 		return
 	}
 
@@ -166,11 +166,11 @@ func handleGetMapping(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if ret == nil {
-		httpapi.RespondESError(w, errors.New("unable to obtain mapping for template"))
+		httpapi.RespondESError(r.Context(), w, errors.New("unable to obtain mapping for template"))
 		return
 	}
 
-	httpapi.RespondJSON(w, 200, ret)
+	httpapi.RespondJSON(r.Context(), w, 200, ret)
 }
 
 func handleLatestTemplate(w http.ResponseWriter, r *http.Request) {
@@ -185,7 +185,7 @@ func handleLatestTemplate(w http.ResponseWriter, r *http.Request) {
 		o5Fsc,
 	)
 
-	httpapi.RespondSearch(w, searchService)
+	httpapi.RespondSearch(r.Context(), w, searchService)
 }
 
 func handleGetTemplate(w http.ResponseWriter, r *http.Request) {
@@ -204,5 +204,5 @@ func handleGetTemplate(w http.ResponseWriter, r *http.Request) {
 		o5Fsc,
 	)
 
-	httpapi.RespondSearch(w, searchService)
+	httpapi.RespondSearch(r.Context(), w, searchService)
 }

--- a/sync/api.go
+++ b/sync/api.go
@@ -15,7 +15,7 @@ func init() {
 	syncRouter.HandleFunc("/status", HandleStatus)
 }
 
-func HandleStatus(w http.ResponseWriter, _ *http.Request) {
+func HandleStatus(w http.ResponseWriter, r *http.Request) {
 	lb := recentBlocks.PeekFront()
 
 	count, err := flo.GetBlockCount()
@@ -31,13 +31,13 @@ func HandleStatus(w http.ResponseWriter, _ *http.Request) {
 		time = lb.Block.Time
 	}
 
-	httpapi.RespondJSON(w, http.StatusOK, map[string]interface{}{
-		"IsInitialSync": IsInitialSync,
+	httpapi.RespondJSON(r.Context(), w, http.StatusOK, map[string]interface{}{
+		"IsInitialSync":         IsInitialSync,
 		"MultipartSyncComplete": MultipartSyncComplete,
-		"EditSyncComplete": EditSyncComplete,
-		"Height":        height,
-		"Timestamp":     time,
-		"LatestHeight":  count,
-		"Progress":      float64(height) / float64(count),
+		"EditSyncComplete":      EditSyncComplete,
+		"Height":                height,
+		"Timestamp":             time,
+		"LatestHeight":          count,
+		"Progress":              float64(height) / float64(count),
 	})
 }


### PR DESCRIPTION
#21 

Adds the `?pretty=X` option to all JSON API routes

Responses will be pretty formatted when X is one of `1, t, T, TRUE, true, True`  any other value will not